### PR TITLE
Fixed import urllib in load_mnist

### DIFF
--- a/perceptron/utils.py
+++ b/perceptron/utils.py
@@ -89,7 +89,7 @@ def load_mnist():
         if not os.path.isdir(repo):
             os.mkdir(repo)
 
-            import urllib
+            import urllib.request
             urllib.request.urlretrieve('http://www.cs.toronto.edu/~larocheh/public/datasets/mnist/mnist_train.txt', os.path.join(repo, 'mnist_train.txt'))
             urllib.request.urlretrieve('http://www.cs.toronto.edu/~larocheh/public/datasets/mnist/mnist_valid.txt', os.path.join(repo, 'mnist_valid.txt'))
             urllib.request.urlretrieve('http://www.cs.toronto.edu/~larocheh/public/datasets/mnist/mnist_test.txt', os.path.join(repo, 'mnist_test.txt'))


### PR DESCRIPTION
Weird things happen when not importing directly `urllib.request` in Python3.
